### PR TITLE
feat: program change custom logic

### DIFF
--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2025,11 +2025,8 @@ void SurgeSynthesizer::polyAftertouch(char channel, int key, int value)
 
 void SurgeSynthesizer::programChange(char channel, int value)
 {
-    PCH = value;
-
-    auto pid = storage.patchIdToMidiBankAndProgram[CC0][PCH];
-    if (pid >= 0)
-        patchid_queue = pid;
+    bool increment = value == 127;
+    jogPatchOrCategory(increment, false, true);
 }
 
 void SurgeSynthesizer::updateDisplay()

--- a/src/common/SurgeSynthesizer.cpp
+++ b/src/common/SurgeSynthesizer.cpp
@@ -2025,8 +2025,17 @@ void SurgeSynthesizer::polyAftertouch(char channel, int key, int value)
 
 void SurgeSynthesizer::programChange(char channel, int value)
 {
-    bool increment = value == 127;
-    jogPatchOrCategory(increment, false, true);
+    bool incrementPatch = value == 127;
+    bool decrementPatch = value == 0;
+    if (incrementPatch || decrementPatch) {
+        jogPatchOrCategory(incrementPatch, false, true);
+    }
+    
+    bool incrementCategory = value == 126;
+    bool decrementCategory = value == 1;
+    if (incrementCategory || decrementCategory) {
+        jogPatchOrCategory(incrementCategory, true);
+    }
 }
 
 void SurgeSynthesizer::updateDisplay()

--- a/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
+++ b/src/surge-xt/gui/SurgeJUCELookAndFeel.cpp
@@ -220,11 +220,12 @@ void SurgeJUCELookAndFeel::drawDocumentWindowTitleBar(DocumentWindow &window, Gr
     auto wt = window.getName();
 
     String surgeLabel = "Surge XT";
-    String surgeVersion = Surge::Build::FullVersionStr;
+    String surgeVersion = "";
     auto fontSurge = skin->fontManager->getLatoAtSize(14, juce::Font::bold);
     auto fontVersion = skin->fontManager->getFiraMonoAtSize(14, juce::Font::bold);
 
 #if BUILD_IS_DEBUG
+    surgeVersion += Surge::Build::FullVersionStr;
     surgeVersion += " DEBUG";
 #endif
 


### PR DESCRIPTION
The idea is to bring support of controlling preset switching (next/prev) with Program Change midi commands. Midi Standard does not have a specification for iterating synth presets, which almost every hardware synth does have. PC messages are only used to select predefined presets from a bank instead.

This PR reassigns PC midi messages to behave as iterator, or alternative to gui buttons "Next preset"/ "Prev preset".
The current logic is the following:
* PC message `127` will switch to  `next` preset.
* PC message `0` will switch to  `next` preset category.
* PC message `126` will switch to  `previous` preset.
* PC message `1` will switch to  `previous` preset category.