### PR TITLE
feat: ios support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,8 @@ buildmac/
 buildwin/
 buildxt/
 build-arm/
-build_lv2
+build_ios/
+build_lv2/
 buildiwyu/
 buildpy/
 cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
       add_compile_options(
         -faligned-allocation
         -fasm-blocks
+        -Wno-shorten-64-to-32
       )
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^GNU$")

--- a/libs/sqlite-3.23.3/CMakeLists.txt
+++ b/libs/sqlite-3.23.3/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${PROJECT_NAME} sqlite3.c sqlite3.h)
 add_library(surge::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE .)
 target_compile_definitions(${PROJECT_NAME} PUBLIC
+    HAVE_GETHOSTUUID=1
     SQLITE_OMIT_AUTHORIZATION=1
     SQLITE_OMIT_COMPILEOPTION_DIAGS=1
     SQLITE_OMIT_DEPRECATED=1

--- a/src/cmake/lib.cmake
+++ b/src/cmake/lib.cmake
@@ -54,13 +54,15 @@ function(surge_juce_package target product_name)
       set(dotexe "")
     endif()
 
-    add_custom_command(
-            TARGET ${pkg_target}
-            POST_BUILD
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMAND echo "${target}: Relocating ${target}-cli executable"
-            COMMAND ${CMAKE_COMMAND} -E copy ${cli_dir}/${target}-cli${dotexe} ${SURGE_PRODUCT_DIR}/
-    )
+    if (NOT SURGE_XT_BUILD_AUV3)
+      add_custom_command(
+              TARGET ${pkg_target}
+              POST_BUILD
+              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+              COMMAND echo "${target}: Relocating ${target}-cli executable"
+              COMMAND ${CMAKE_COMMAND} -E copy ${cli_dir}/${target}-cli${dotexe} ${SURGE_PRODUCT_DIR}/
+      )
+    endif()
 
   endif()
 

--- a/src/surge-xt/CMakeLists.txt
+++ b/src/surge-xt/CMakeLists.txt
@@ -235,13 +235,15 @@ if(APPLE)
   set(cliexe ${cliname}/${PROJECT_NAME}-cli)
   message(STATUS "macOS Standalone includes CLI")
 
-  add_custom_command(
-    TARGET ${PROJECT_NAME}_Standalone
-    POST_BUILD
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND echo "Relocating cli executable into Standalone"
-    COMMAND ${CMAKE_COMMAND} -E copy "${cliexe}" "${saname}/Surge XT.app/Contents/MacOS"
-  )
+  if (NOT SURGE_XT_BUILD_AUV3)
+    add_custom_command(
+      TARGET ${PROJECT_NAME}_Standalone
+      POST_BUILD
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND echo "Relocating cli executable into Standalone"
+      COMMAND ${CMAKE_COMMAND} -E copy "${cliexe}" "${saname}/Surge XT.app/Contents/MacOS"
+    )
+  endif()
 endif()
 
 surge_juce_package(${PROJECT_NAME} "Surge XT")

--- a/src/surge-xt/SurgeSynthProcessor.cpp
+++ b/src/surge-xt/SurgeSynthProcessor.cpp
@@ -45,9 +45,12 @@
 SurgeSynthProcessor::SurgeSynthProcessor()
     : juce::AudioProcessor(BusesProperties()
                                .withOutput("Output", juce::AudioChannelSet::stereo(), true)
+#if ! JUCE_IOS
                                .withInput("Sidechain", juce::AudioChannelSet::stereo(), true)
                                .withOutput("Scene A", juce::AudioChannelSet::stereo(), false)
-                               .withOutput("Scene B", juce::AudioChannelSet::stereo(), false))
+                               .withOutput("Scene B", juce::AudioChannelSet::stereo(), false)
+#endif
+                            )
 {
     // Since we are using 'external clap' this is the one JUCE API we can't override
     std::string wrapperTypeString = getWrapperTypeDescription(wrapperType);


### PR DESCRIPTION
# Description
Surge is a great opensource synth, but unfortunately it doesn't work on ios platform, which has surprisingly good experience in audio apps for a mobile platform. Even to build working plugin from sources is not a trivial task. The issues were raised several times in original repo (like https://github.com/surge-synthesizer/surge/issues/3693), but the problem is Surge license (GPL-3.0) is not easily compatible with Apple App Store.

### Motivation
At the beginning of 2024 Apple [was forced](https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union) by European's DMA to provide more ways for users to install applications in iOS. It may potentially mean that users might be able to `sideload` own apps in iOS 17.4.
Also there are alternative ways for apps `sideloading` like `TrollStore` and `Sideloadly` at the moment. It means users may install (sideload) `*.ipa` applications manually without a jailbreak and with minimal altering of some ios systems.
All of these may make ios version of opensource apps like Surge to be more usable than it was before.

### Changes
This PR introduces minimal set of changes needed to build AUv3 version of surge for iOS. The build instructions will be provided in the next PR's.
